### PR TITLE
Upgrade the version of metrics to 3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </parent>
 
   <artifactId>metrics</artifactId>
-  <version>3.0.12-SNAPSHOT</version>
+  <version>3.1.2-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Metrics Plugin</name>
@@ -68,7 +68,7 @@
   </scm>
 
   <properties>
-    <metrics.version>3.0.2</metrics.version>
+    <metrics.version>3.1.2</metrics.version>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -107,27 +107,27 @@
     </dependency>
     <!-- regular dependencies -->
     <dependency>
-      <groupId>com.codahale.metrics</groupId>
+      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
       <version>${metrics.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.codahale.metrics</groupId>
+      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-servlet</artifactId>
       <version>${metrics.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.codahale.metrics</groupId>
+      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-healthchecks</artifactId>
       <version>${metrics.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.codahale.metrics</groupId>
+      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-jvm</artifactId>
       <version>${metrics.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.codahale.metrics</groupId>
+      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-json</artifactId>
       <version>${metrics.version}</version>
     </dependency>

--- a/src/main/java/jenkins/metrics/api/Metrics.java
+++ b/src/main/java/jenkins/metrics/api/Metrics.java
@@ -460,6 +460,9 @@ public class Metrics extends Plugin {
                     }
                 }
             }
+            for (String key: removed) {
+                registry.unregister(key);
+            }
 
             listener.getLogger().println("Starting health checks at " + new Date());
             Timer.Context context = healthCheckDuration.time();


### PR DESCRIPTION
involves a group id change but the package names are the same.

Also fix a bug caught by findbugs

@reviewbybees