### PR TITLE
[JENKINS-32695] Result from health checks are lost when more than 3 run at the same time

### DIFF
--- a/src/main/java/jenkins/metrics/api/Metrics.java
+++ b/src/main/java/jenkins/metrics/api/Metrics.java
@@ -297,9 +297,12 @@ public class Metrics extends Plugin {
         }
         for (HealthCheckProvider p : Jenkins.getInstance().getExtensionList(HealthCheckProvider.class)) {
             LOGGER.log(Level.FINER, "Registering health check provider {0} (type {1})", new Object[]{p, p.getClass()});
-            for (Map.Entry<String, HealthCheck> c : p.getHealthChecks().entrySet()) {
+            Map<String, HealthCheck> healthChecks = p.getHealthChecks();
+            for (Map.Entry<String, HealthCheck> c : healthChecks.entrySet()) {
                 plugin.healthCheckRegistry.register(c.getKey(), c.getValue());
             }
+            LOGGER.log(Level.FINER, "Registered health check provider {0} (type {1}) with {2} checks: {3}",
+                    new Object[] { p, p.getClass(), healthChecks.size(), healthChecks.keySet() });
         }
         threadPoolForHealthChecks = new HealthChecksThreadPool(healthCheckRegistry());
         LOGGER.log(Level.FINE, "Metric provider and health check provider extensions registered");

--- a/src/main/java/jenkins/metrics/api/Metrics.java
+++ b/src/main/java/jenkins/metrics/api/Metrics.java
@@ -486,8 +486,9 @@ public class Metrics extends Plugin {
             try {
                 results = registry.runHealthChecks(threadPoolForHealthChecks);
             } catch (RejectedExecutionException e) {
-                listener.error("Health checks execution is rejected due to: {0}", e.getMessage());
-                LOGGER.log(Level.INFO, "Health checks execution is rejected due to: {0}", e.getMessage());
+                // should never happen, as we are using a DiscardOldestPolicy in the thread pool queue
+                listener.error("Health checks execution was rejected instead of queued: {0}", e);
+                LOGGER.log(Level.WARNING, "Health checks execution was rejected instead of queued: {0}", e);
                 return;
             } finally {
                 context.stop();

--- a/src/main/java/jenkins/metrics/util/HealthChecksThreadPool.java
+++ b/src/main/java/jenkins/metrics/util/HealthChecksThreadPool.java
@@ -77,6 +77,10 @@ public class HealthChecksThreadPool extends ThreadPoolExecutor {
                         return new Thread(r, "Metrics-HealthChecks-" + number.incrementAndGet());
                     }
                 })), new MetricsRejectedExecutionHandler(healthCheckRegistry));
+        LOGGER.log(Level.FINE,
+                "Created thread pool with a max of {0} threads (plus {1} in queue) for {2} health checks",
+                new Object[] { getMaximumPoolSize(), getQueue().remainingCapacity(),
+                        healthCheckRegistry.getNames().size() });
     }
 
     @Restricted(DoNotUse.class) // testing only

--- a/src/main/java/jenkins/metrics/util/HealthChecksThreadPool.java
+++ b/src/main/java/jenkins/metrics/util/HealthChecksThreadPool.java
@@ -39,7 +39,6 @@ import com.codahale.metrics.health.HealthCheckRegistry;
 
 import hudson.util.DaemonThreadFactory;
 import hudson.util.ExceptionCatchingThreadFactory;
-import jenkins.metrics.api.Metrics;
 
 /**
  * Thread pool for running health checks. We set the pool size to 4 (max) and we keep threads around for 5 seconds as
@@ -51,7 +50,7 @@ import jenkins.metrics.api.Metrics;
  */
 public class HealthChecksThreadPool extends ThreadPoolExecutor {
 
-    private static final Logger LOGGER = Logger.getLogger(Metrics.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(HealthChecksThreadPool.class.getName());
 
     private static final int MAX_THREAD_POOL_SIZE = 4;
     private static long rejectedExecutions;

--- a/src/main/java/jenkins/metrics/util/HealthChecksThreadPool.java
+++ b/src/main/java/jenkins/metrics/util/HealthChecksThreadPool.java
@@ -42,8 +42,9 @@ import hudson.util.ExceptionCatchingThreadFactory;
 import jenkins.metrics.api.Metrics.HealthChecker;
 
 /**
- * Thread pool for running health checks. We set the pool size to 4 (max) and we keep threads around for 5 seconds as
- * this is a bursty pool used once per minute.
+ * Thread pool for running health checks. We set the pool size to 4 by default (configurable with system property
+ * HEALTH_CHECKER_MAX_THREAD_POOL_SIZE) and we keep threads around for 5 seconds as this is a bursty pool used once per
+ * minute.
  * 
  * The queue is set to the same size as the number of health checks, minus the 4 threads in the pool, plus one, as the
  * {@link HealthChecker} itself is executed in the pool too. For example for 10 health checks we have the thread pool
@@ -58,7 +59,9 @@ public class HealthChecksThreadPool extends ThreadPoolExecutor {
 
     private static final Logger LOGGER = Logger.getLogger(HealthChecksThreadPool.class.getName());
 
-    private static final int MAX_THREAD_POOL_SIZE = 4;
+    private static final int MAX_THREAD_POOL_SIZE = Integer
+            .parseInt(System.getProperty("HEALTH_CHECKER_MAX_THREAD_POOL_SIZE", "4"));
+
     private static long rejectedExecutions;
 
     public HealthChecksThreadPool(HealthCheckRegistry healthCheckRegistry) {

--- a/src/main/java/jenkins/metrics/util/HealthChecksThreadPool.java
+++ b/src/main/java/jenkins/metrics/util/HealthChecksThreadPool.java
@@ -1,0 +1,103 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.metrics.util;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+
+import com.codahale.metrics.health.HealthCheckRegistry;
+
+import hudson.util.DaemonThreadFactory;
+import hudson.util.ExceptionCatchingThreadFactory;
+import jenkins.metrics.api.Metrics;
+
+/**
+ * Thread pool for running health checks. We set the pool size to 4 (max) and we keep threads around for 5 seconds as
+ * this is a bursty pool used once per minute. The queue is set to the same size as the number of health checks,
+ * dropping oldest items in the queue as new ones come in, to avoid running more than one health check in each
+ * recurrence period.
+ * 
+ * @since 3.1.2.3
+ */
+public class HealthChecksThreadPool extends ThreadPoolExecutor {
+
+    private static final Logger LOGGER = Logger.getLogger(Metrics.class.getName());
+
+    private static final int MAX_THREAD_POOL_SIZE = 4;
+    private static long rejectedExecutions;
+
+    public HealthChecksThreadPool(HealthCheckRegistry healthCheckRegistry) {
+        super(0, MAX_THREAD_POOL_SIZE, //
+                5L, TimeUnit.SECONDS, //
+                // 1 thread is taken by the executor itself
+                new ArrayBlockingQueue<Runnable>(
+                        Math.max(0, 1 + healthCheckRegistry.getNames().size() - MAX_THREAD_POOL_SIZE)), //
+                new ExceptionCatchingThreadFactory(new DaemonThreadFactory(new ThreadFactory() {
+                    private final AtomicInteger number = new AtomicInteger();
+
+                    public Thread newThread(Runnable r) {
+                        return new Thread(r, "Metrics-HealthChecks-" + number.incrementAndGet());
+                    }
+                })), new MetricsRejectedExecutionHandler(healthCheckRegistry));
+    }
+
+    @Restricted(DoNotUse.class) // testing only
+    public static long getRejectedExecutions() {
+        return rejectedExecutions;
+    }
+
+    /**
+     * Log the rejection and execute the {@link DiscardOldestPolicy} handler, dropping the first item in the queue and
+     * retrying
+     */
+    private static class MetricsRejectedExecutionHandler extends DiscardOldestPolicy
+            implements RejectedExecutionHandler {
+
+        private HealthCheckRegistry healthCheckRegistry;
+
+        public MetricsRejectedExecutionHandler(HealthCheckRegistry healthCheckRegistry) {
+            this.healthCheckRegistry = healthCheckRegistry;
+        }
+
+        public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+            rejectedExecutions++;
+            LOGGER.log(Level.WARNING,
+                    "Execution of health check was rejected, will drop oldest in queue, this may mean some health checks are taking too long to execute:"
+                            + " {0}, queue max size={1}, health checks={2} ({3})",
+                    new Object[] { executor, executor.getQueue().size(), healthCheckRegistry.getNames(),
+                            healthCheckRegistry.getNames().size() });
+            super.rejectedExecution(r, executor);
+        }
+    }
+
+}

--- a/src/main/java/jenkins/metrics/util/HealthChecksThreadPool.java
+++ b/src/main/java/jenkins/metrics/util/HealthChecksThreadPool.java
@@ -39,12 +39,18 @@ import com.codahale.metrics.health.HealthCheckRegistry;
 
 import hudson.util.DaemonThreadFactory;
 import hudson.util.ExceptionCatchingThreadFactory;
+import jenkins.metrics.api.Metrics.HealthChecker;
 
 /**
  * Thread pool for running health checks. We set the pool size to 4 (max) and we keep threads around for 5 seconds as
- * this is a bursty pool used once per minute. The queue is set to the same size as the number of health checks,
- * dropping oldest items in the queue as new ones come in, to avoid running more than one health check in each
- * recurrence period.
+ * this is a bursty pool used once per minute.
+ * 
+ * The queue is set to the same size as the number of health checks, minus the 4 threads in the pool, plus one, as the
+ * {@link HealthChecker} itself is executed in the pool too. For example for 10 health checks we have the thread pool
+ * (4) + the queue (7) = 11 for the 10 health checks and the HealthChecker.
+ * 
+ * The {@link RejectedExecutionHandler} is configured to drop oldest items in the queue as new ones come in, to avoid
+ * running more than one health check in each recurrence period.
  * 
  * @since 3.1.2.3
  */

--- a/src/main/java/jenkins/metrics/util/HealthChecksThreadPool.java
+++ b/src/main/java/jenkins/metrics/util/HealthChecksThreadPool.java
@@ -43,8 +43,8 @@ import jenkins.metrics.api.Metrics.HealthChecker;
 
 /**
  * Thread pool for running health checks. We set the pool size to 4 by default (configurable with system property
- * HEALTH_CHECKER_MAX_THREAD_POOL_SIZE) and we keep threads around for 5 seconds as this is a bursty pool used once per
- * minute.
+ * jenkins.metrics.util.HealthChecksThreadPool.maxThreadNumber) and we keep threads around for 5 seconds as this is a
+ * bursty pool used once per minute.
  * 
  * The queue is set to the same size as the number of health checks, minus the 4 threads in the pool, plus one, as the
  * {@link HealthChecker} itself is executed in the pool too. For example for 10 health checks we have the thread pool
@@ -60,7 +60,7 @@ public class HealthChecksThreadPool extends ThreadPoolExecutor {
     private static final Logger LOGGER = Logger.getLogger(HealthChecksThreadPool.class.getName());
 
     private static final int MAX_THREAD_POOL_SIZE = Integer
-            .parseInt(System.getProperty("HEALTH_CHECKER_MAX_THREAD_POOL_SIZE", "4"));
+            .parseInt(System.getProperty(HealthChecksThreadPool.class.getName() + ".maxThreadNumber", "4"));
 
     private static long rejectedExecutions;
 

--- a/src/test/java/jenkins/metrics/api/HealthCheckProviderForTesting.java
+++ b/src/test/java/jenkins/metrics/api/HealthCheckProviderForTesting.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.metrics.api;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.codahale.metrics.health.HealthCheck;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+
+@Extension
+public class HealthCheckProviderForTesting extends HealthCheckProvider {
+
+    public static int runs;
+
+    @NonNull
+    @Override
+    public Map<String, HealthCheck> getHealthChecks() {
+        return checks(check(1), check(2), check(3), check(4), check(5), check(6));
+    }
+
+    private Entry<String, HealthCheck> check(int i) {
+        return check("short-running-health-check-" + i, new HealthCheck() {
+            @Override
+            protected Result check() throws Exception {
+                runs++;
+                Thread.sleep(1 * 1000);
+                return Result.unhealthy("some error message");
+            }
+        });
+    }
+}

--- a/src/test/java/jenkins/metrics/api/HealthCheckerTest.java
+++ b/src/test/java/jenkins/metrics/api/HealthCheckerTest.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.metrics.api;
+
+import static org.junit.Assert.*;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import jenkins.metrics.api.Metrics.HealthChecker;
+import jenkins.metrics.util.HealthChecksThreadPool;
+
+/**
+ * Test the {@link HealthChecker} execution of health checks
+ */
+public class HealthCheckerTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testHealthChecksAreNotRejected() throws Exception {
+        while (HealthCheckProviderForTesting.runs < 6 && HealthChecksThreadPool.getRejectedExecutions() == 0) {
+            Thread.sleep(1000);
+        }
+        assertEquals(0, HealthChecksThreadPool.getRejectedExecutions());
+    }
+
+}


### PR DESCRIPTION
If more than 3 checks are put in the pool before one finishes a RejectedExecutionException is thrown,
never logged anywhere, and nothing is returned from registry.runHealthChecks

@reviewbybees 