### PR TITLE
[WiP][JENKINS-32696] Healthcheck API endpoint causes a new run of health checks

### DIFF
--- a/src/main/java/jenkins/metrics/api/Metrics.java
+++ b/src/main/java/jenkins/metrics/api/Metrics.java
@@ -168,12 +168,12 @@ public class Metrics extends Plugin {
         Jenkins jenkins = Jenkins.getInstance();
         if (jenkins == null) {
             LOGGER.warning("Unable to get health check results, client master is not ready (startup or shutdown)");
-            return Collections.emptySortedMap();
+            return new TreeMap<String, Result>();
         }
         HealthChecker healthChecker = jenkins.getExtensionList(PeriodicWork.class).get(HealthChecker.class);
         if (healthChecker == null) {
             LOGGER.warning("Unable to get health check results, HealthChecker is not available");
-            return Collections.emptySortedMap();
+            return new TreeMap<String, Result>();
         }
         return healthChecker.getSortedHealthCheckResults();
     }

--- a/src/main/java/jenkins/metrics/api/Metrics.java
+++ b/src/main/java/jenkins/metrics/api/Metrics.java
@@ -31,6 +31,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.MetricSet;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheck.Result;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
@@ -58,12 +59,13 @@ import org.kohsuke.stapler.HttpResponse;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -74,6 +76,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import javax.annotation.Nonnull;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
@@ -152,6 +156,26 @@ public class Metrics extends Plugin {
             throw new AssertionError(Metrics.class.getName() + " is missing its HealthCheckRegistry");
         }
         return plugin.healthCheckRegistry;
+    }
+
+    /**
+     * Get the last health check results
+     * 
+     * @return a map with health check name -> health check result
+     */
+    @Nonnull
+    public static SortedMap<String, Result> getHealthCheckResults() {
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins == null) {
+            LOGGER.warning("Unable to get health check results, client master is not ready (startup or shutdown)");
+            return Collections.emptySortedMap();
+        }
+        HealthChecker healthChecker = jenkins.getExtensionList(PeriodicWork.class).get(HealthChecker.class);
+        if (healthChecker == null) {
+            LOGGER.warning("Unable to get health check results, HealthChecker is not available");
+            return Collections.emptySortedMap();
+        }
+        return healthChecker.getSortedHealthCheckResults();
     }
 
     /**
@@ -379,7 +403,7 @@ public class Metrics extends Plugin {
 
         private final Timer healthCheckDuration = new Timer();
 
-        private Map<String, HealthCheck.Result> healthCheckResults = new HashMap<String, HealthCheck.Result>();
+        private SortedMap<String, HealthCheck.Result> healthCheckResults = new TreeMap<String, HealthCheck.Result>();
 
         private final Gauge<Integer> healthCheckCount = new Gauge<Integer>() {
             public Integer getValue() {
@@ -409,6 +433,10 @@ public class Metrics extends Plugin {
         }
 
         public Map<String, HealthCheck.Result> getHealthCheckResults() {
+            return getSortedHealthCheckResults();
+        }
+
+        public SortedMap<String, HealthCheck.Result> getSortedHealthCheckResults() {
             return healthCheckResults;
         }
 

--- a/src/main/java/jenkins/metrics/api/MetricsRootAction.java
+++ b/src/main/java/jenkins/metrics/api/MetricsRootAction.java
@@ -158,7 +158,7 @@ public class MetricsRootAction implements UnprotectedRootAction {
             key = getKeyFromAuthorizationHeader(req);
         }
         Metrics.checkAccessKeyHealthCheck(key);
-        return Metrics.cors(key, new HealthCheckResponse(Metrics.healthCheckRegistry().runHealthChecks()));
+        return Metrics.cors(key, new HealthCheckResponse(Metrics.getHealthCheckResults()));
     }
 
     /**
@@ -173,7 +173,7 @@ public class MetricsRootAction implements UnprotectedRootAction {
      * return status 200 if everything is OK, 503 (service unavailable) otherwise
      */
     public HttpResponse doHealthcheckOk() {
-        SortedMap<String, HealthCheck.Result> checks =  Metrics.healthCheckRegistry().runHealthChecks();
+        SortedMap<String, HealthCheck.Result> checks =  Metrics.getHealthCheckResults();
         boolean allOk = true;
         for(Map.Entry<String, HealthCheck.Result> entry: checks.entrySet()){
             HealthCheck.Result result = entry.getValue();
@@ -401,7 +401,7 @@ public class MetricsRootAction implements UnprotectedRootAction {
     public class Pseudoservlet {
 
         public HttpResponse doHealthcheck() {
-            return new HealthCheckResponse(Metrics.healthCheckRegistry().runHealthChecks());
+            return new HealthCheckResponse(Metrics.getHealthCheckResults());
         }
 
         public HttpResponse doMetrics() {


### PR DESCRIPTION
Instead of reusing previous values