### PR TITLE
[JENKINS-32696] Healthcheck API endpoint causes a new run of health checks

### DIFF
--- a/src/main/java/jenkins/metrics/api/Metrics.java
+++ b/src/main/java/jenkins/metrics/api/Metrics.java
@@ -33,6 +33,7 @@ import com.codahale.metrics.Timer;
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheck.Result;
 import com.codahale.metrics.health.HealthCheckRegistry;
+import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
 import jenkins.metrics.impl.MetricsFilter;
@@ -58,7 +59,6 @@ import org.kohsuke.stapler.HttpResponse;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Map;
@@ -160,7 +160,7 @@ public class Metrics extends Plugin {
             LOGGER.warning("Unable to get health check results, HealthChecker is not available");
             return new TreeMap<String, Result>();
         }
-        return healthChecker.getSortedHealthCheckResults();
+        return healthChecker.getHealthCheckResults();
     }
 
     /**
@@ -421,11 +421,8 @@ public class Metrics extends Plugin {
             return healthCheckDuration;
         }
 
-        public Map<String, HealthCheck.Result> getHealthCheckResults() {
-            return getSortedHealthCheckResults();
-        }
-
-        public SortedMap<String, HealthCheck.Result> getSortedHealthCheckResults() {
+        @WithBridgeMethods(Map.class)
+        public SortedMap<String, HealthCheck.Result> getHealthCheckResults() {
             return healthCheckResults;
         }
 

--- a/src/main/java/jenkins/metrics/api/Metrics.java
+++ b/src/main/java/jenkins/metrics/api/Metrics.java
@@ -34,14 +34,12 @@ import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheck.Result;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
-import hudson.init.InitMilestone;
-import hudson.init.Initializer;
-import javax.annotation.concurrent.ThreadSafe;
-import jenkins.metrics.impl.MetricsFilter;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Plugin;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
 import hudson.model.PeriodicWork;
 import hudson.model.TaskListener;
 import hudson.security.ACL;
@@ -51,13 +49,6 @@ import hudson.security.PermissionScope;
 import hudson.util.PluginServletFilter;
 import hudson.util.StreamTaskListener;
 import hudson.util.TimeUnit2;
-import jenkins.model.Jenkins;
-import jenkins.metrics.util.HealthChecksThreadPool;
-
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.HttpResponse;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Date;
@@ -72,8 +63,13 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import javax.annotation.Nonnull;
+import jenkins.metrics.impl.MetricsFilter;
+import jenkins.metrics.util.HealthChecksThreadPool;
+import jenkins.model.Jenkins;
+import net.jcip.annotations.ThreadSafe;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.HttpResponse;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
@@ -149,7 +145,7 @@ public class Metrics extends Plugin {
      * 
      * @return a map with health check name -> health check result
      */
-    @Nonnull
+    @NonNull
     public static SortedMap<String, Result> getHealthCheckResults() {
         Jenkins jenkins = Jenkins.getInstance();
         if (jenkins == null) {

--- a/src/main/java/jenkins/metrics/api/Metrics.java
+++ b/src/main/java/jenkins/metrics/api/Metrics.java
@@ -594,7 +594,7 @@ public class Metrics extends Plugin {
     @ThreadSafe
     public static class HealthCheckData {
         private final long lastModified;
-        private final long expires;
+        private final Long expires;
         private final SortedMap<String, HealthCheck.Result> results;
 
         public HealthCheckData(SortedMap<String, Result> results, long nextMillis) {
@@ -603,11 +603,17 @@ public class Metrics extends Plugin {
             this.expires = lastModified + nextMillis;
         }
 
+        public HealthCheckData(SortedMap<String, Result> results) {
+            this.results = results;
+            this.lastModified = System.currentTimeMillis();
+            this.expires = null;
+        }
+
         public long getLastModified() {
             return lastModified;
         }
 
-        public long getExpires() {
+        public Long getExpires() {
             return expires;
         }
 

--- a/src/main/java/jenkins/metrics/api/Metrics.java
+++ b/src/main/java/jenkins/metrics/api/Metrics.java
@@ -153,12 +153,12 @@ public class Metrics extends Plugin {
         Jenkins jenkins = Jenkins.getInstance();
         if (jenkins == null) {
             LOGGER.warning("Unable to get health check results, client master is not ready (startup or shutdown)");
-            return Collections.emptySortedMap();
+            return new TreeMap<String, Result>();
         }
         HealthChecker healthChecker = jenkins.getExtensionList(PeriodicWork.class).get(HealthChecker.class);
         if (healthChecker == null) {
             LOGGER.warning("Unable to get health check results, HealthChecker is not available");
-            return Collections.emptySortedMap();
+            return new TreeMap<String, Result>();
         }
         return healthChecker.getSortedHealthCheckResults();
     }

--- a/src/main/java/jenkins/metrics/api/MetricsRootAction.java
+++ b/src/main/java/jenkins/metrics/api/MetricsRootAction.java
@@ -1041,7 +1041,7 @@ public class MetricsRootAction implements UnprotectedRootAction {
         /**
          * A sample.
          */
-        @SuppressWarnings(value = "EI_EXPOSE_REP2")
+        @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "EI_EXPOSE_REP2")
         public static class Sample {
             /**
              * The time when the sample was captured.

--- a/src/main/java/jenkins/metrics/api/MetricsRootAction.java
+++ b/src/main/java/jenkins/metrics/api/MetricsRootAction.java
@@ -188,7 +188,7 @@ public class MetricsRootAction implements UnprotectedRootAction {
         Metrics.HealthCheckData data = Metrics.getHealthCheckData();
         if (data == null) {
             // TODO perhaps block until the result is available
-            return HttpResponses.status(503);
+            return HttpResponses.status(200);
         }
         if (ifModifiedSince != -1 && data.getLastModified() < ifModifiedSince) {
             return HttpResponses.status(HttpServletResponse.SC_NOT_MODIFIED);

--- a/src/main/java/jenkins/metrics/api/MetricsRootAction.java
+++ b/src/main/java/jenkins/metrics/api/MetricsRootAction.java
@@ -158,7 +158,7 @@ public class MetricsRootAction implements UnprotectedRootAction {
             key = getKeyFromAuthorizationHeader(req);
         }
         Metrics.checkAccessKeyHealthCheck(key);
-        return Metrics.cors(key, new HealthCheckResponse(Metrics.healthCheckRegistry().runHealthChecks()));
+        return Metrics.cors(key, new HealthCheckResponse(Metrics.getHealthCheckResults()));
     }
 
     /**
@@ -173,7 +173,7 @@ public class MetricsRootAction implements UnprotectedRootAction {
      * return status 200 if everything is OK, 503 (service unavailable) otherwise
      */
     public HttpResponse doHealthcheckOk() {
-        SortedMap<String, HealthCheck.Result> checks =  Metrics.healthCheckRegistry().runHealthChecks();
+        SortedMap<String, HealthCheck.Result> checks =  Metrics.getHealthCheckResults();
         boolean allOk = true;
         for(Map.Entry<String, HealthCheck.Result> entry: checks.entrySet()){
             HealthCheck.Result result = entry.getValue();
@@ -401,7 +401,7 @@ public class MetricsRootAction implements UnprotectedRootAction {
     public class Pseudoservlet {
 
         public HttpResponse doHealthcheck() {
-            return new HealthCheckResponse(Metrics.healthCheckRegistry().runHealthChecks());
+            return new HealthCheckResponse(Metrics.getHealthCheckResults());
         }
 
         public HttpResponse doMetrics() {


### PR DESCRIPTION
Rework of #19 

- [x] Add support for `If-Modified-Since` request header
- [x] Add support for `Last-Modified` and `Expires` response headers
- [x] Tweak cache control to include `max-age`
- [x] Decide if we should implement a blocking mode when the request includes a `max-age` cache control from the client per [RFC 2616 Section 14.9.3](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.3) and the current age is more than the requested max-age