### PR TITLE
Expose metrics via JMX

### DIFF
--- a/src/main/java/jenkins/metrics/api/Metrics.java
+++ b/src/main/java/jenkins/metrics/api/Metrics.java
@@ -26,6 +26,7 @@ package jenkins.metrics.api;
 
 import com.codahale.metrics.DerivativeGauge;
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.MetricSet;
@@ -125,6 +126,10 @@ public class Metrics extends Plugin {
      * The servlet filter.
      */
     private transient final MetricsFilter filter = new MetricsFilter();
+    /**
+     * Exposes metrics to JMX
+     */
+    private JmxReporter jmxReporter;
 
     /**
      * Returns the {@link HealthCheckRegistry} for the current {@link Jenkins}.
@@ -301,6 +306,8 @@ public class Metrics extends Plugin {
     @Override
     public void start() throws Exception {
         PluginServletFilter.addFilter(filter);
+        jmxReporter = JmxReporter.forRegistry(metricRegistry).build();
+        jmxReporter.start();
     }
 
     /**
@@ -353,6 +360,10 @@ public class Metrics extends Plugin {
         metricRegistry.removeMatching(MetricFilter.ALL);
         for (String name : healthCheckRegistry.getNames()) {
             healthCheckRegistry.unregister(name);
+        }
+        if (jmxReporter!=null) {
+            jmxReporter.stop();
+            jmxReporter = null;
         }
     }
 


### PR DESCRIPTION
This allows Jenkins to work easily with other monitoring tools &
services that have ready-made JMX connectivity, such as:

1. DataDog: http://docs.datadoghq.com/integrations/java/
2. NewRelic: https://docs.newrelic.com/docs/agents/java-agent/custom-instrumentation/custom-jmx-instrumentation-yaml
3. Prometheus: https://github.com/prometheus/jmx_exporter
4. CollectD: https://collectd.org/wiki/index.php/Plugin:GenericJMX
5. IBM Tivoli: https://www.ibm.com/support/knowledgecenter/SSTFXA_6.3.0/com.ibm.itm.doc_6.3/builder/ab_ds_jmx_config.htm
6. Nagios: https://exchange.nagios.org/directory/Plugins/Java-Applications-and-Servers/check_jmx/details