### PR TITLE
JENKINS-47696: renaming metrics for all nodes

### DIFF
--- a/src/main/java/jenkins/metrics/impl/JenkinsMetricProviderImpl.java
+++ b/src/main/java/jenkins/metrics/impl/JenkinsMetricProviderImpl.java
@@ -302,21 +302,21 @@ public class JenkinsMetricProviderImpl extends MetricProvider {
                                 return value.getPending();
                             }
                         }).toMetricSet()),
-                metric(name("jenkins", "node", "count"), (jenkinsNodeTotalCount =
+                metric(name("jenkins", "allnodes", "count"), (jenkinsNodeTotalCount =
                         new AutoSamplingHistogram(new DerivativeGauge<NodeStats, Integer>(jenkinsNodes) {
                             @Override
                             protected Integer transform(NodeStats value) {
                                 return value.getNodeCount();
                             }
                         })).toMetricSet()),
-                metric(name("jenkins", "node", "online"), (jenkinsNodeOnlineCount =
+                metric(name("jenkins", "allnodes", "online"), (jenkinsNodeOnlineCount =
                         new AutoSamplingHistogram(new DerivativeGauge<NodeStats, Integer>(jenkinsNodes) {
                             @Override
                             protected Integer transform(NodeStats value) {
                                 return value.getNodeOnline();
                             }
                         })).toMetricSet()),
-                metric(name("jenkins", "node", "offline"),
+                metric(name("jenkins", "allnodes", "offline"),
                         new AutoSamplingHistogram(new DerivativeGauge<NodeStats, Integer>(jenkinsNodes) {
                             @Override
                             protected Integer transform(NodeStats value) {


### PR DESCRIPTION
**Background:**
We monitor Jenkins with Prometheus and scrape the metrics produced by the metrics-plugin with the jmx-exporter (https://github.com/prometheus/jmx_exporter).
Furthermore, our slaves are ephemeral resulting in different slaves for different builds.

**Motivation:**

Exposed as mBeans and visible via JMX, we see metrics for our slaves denoted by e.g.
`metrics_jenkins_node_scaler_int_i_192_168_148_102_java_4966cfa5_builds_98thPercentile 0.0`
To make maximal use of this metric, Prometheus needs it so scrape in a form like
`metrics_jenkins_node_builds{name="scaler_int_i_192_168_148_102_java_4966cfa5", quantile="0.98"} 0.0`
Such a rewriting can be done with help of rules in the configuration of the JMX-Exporter: https://github.com/prometheus/jmx_exporter#configuration

**Problem:**

To generate rules, we need to apply a regex on the mBean. The prefix "node" would fit perfectly to file for. Unfortunately, the same prefix is used for the following, global node staticstic:

- jenkins.node.count.*
- jenkins.node.offline.*
- jenkins.node.online.*

This prohibits a filtering on node-specifics metrics.
Proposal:
Renaming of 

- jenkins.node.count.*
- jenkins.node.offline.*
- jenkins.node.online.*

to 

- jenkins.allnodes.count.*
- jenkins.allnodes.offline.*
- jenkins.allnodes.online.*
