### PR TITLE
[JENKINS-44486] Prevent UnsupportedOperationException when installing plugins with custom health checks.

### DIFF
--- a/src/main/java/jenkins/metrics/api/Metrics.java
+++ b/src/main/java/jenkins/metrics/api/Metrics.java
@@ -603,7 +603,7 @@ public class Metrics extends Plugin {
             reindexAccessKeys();
             HealthCheckRegistry registry = healthCheckRegistry();
             // update the active health checks
-            Set<String> defined = registry.getNames();
+            Set<String> defined = new HashSet<String>(registry.getNames());
             Set<String> removed = new HashSet<String>(defined);
             Jenkins jenkins = Jenkins.getInstance();
             if (jenkins != null) {


### PR DESCRIPTION
See [JENKINS-44486](https://issues.jenkins-ci.org/browse/JENKINS-44486).

I confirmed that installing the mesos plugin (which defines a [custom health check](https://github.com/jenkinsci/mesos-plugin/blob/master/src/main/java/org/jenkinsci/plugins/mesos/MesosHealthCheck.java)) without restarting Jenkins results in `UnsupportedOperationException`s being logged before this change, and does not cause exceptions after the change.

Since the change appears to be simple and isolated (the `defined` set is only used from line 606 to 615), I have not added any automated tests (famous last words), but am happy to do so if desired.


@reviewbybees 