### PR TITLE
[JENKINS-50291] Move health-checker.log under the now configurable logs root directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.7</version>
+    <version>2.37</version>
   </parent>
 
   <artifactId>metrics</artifactId>

--- a/src/main/java/jenkins/metrics/api/Metrics.java
+++ b/src/main/java/jenkins/metrics/api/Metrics.java
@@ -47,11 +47,14 @@ import hudson.security.ACL;
 import hudson.security.Permission;
 import hudson.security.PermissionGroup;
 import hudson.security.PermissionScope;
+import hudson.triggers.SafeTimerTask;
 import hudson.util.PluginServletFilter;
 import hudson.util.StreamTaskListener;
 import hudson.util.TimeUnit2;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Map;
@@ -595,6 +598,20 @@ public class Metrics extends Plugin {
         /* package */
         static File getLogFile(Jenkins jenkins) {
             File logsRoot = new File(jenkins.getRootDir(), "logs");
+            try {
+                // FIXME : remove when 2.114+ See JENKINS-50291
+                final Method getLogsRoot = SafeTimerTask.class.getMethod("getLogsRoot");
+                logsRoot = (File) getLogsRoot.invoke(null);
+
+            } catch (NoSuchMethodException e) {
+                // Expected on < 2.114
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+                // Expected on < 2.114
+            } catch (InvocationTargetException e) {
+                e.printStackTrace();
+                // Expected on < 2.114
+            }
             return new File(logsRoot, "health-checker.log");
         }
 

--- a/src/main/java/jenkins/metrics/api/Metrics.java
+++ b/src/main/java/jenkins/metrics/api/Metrics.java
@@ -548,7 +548,7 @@ public class Metrics extends Plugin {
                             if (jenkins == null) {
                                 return;
                             }
-                            File logFile = new File(new File(jenkins.getRootDir(), "logs"), "health-checker.log");
+                            File logFile = getLogFile(jenkins);
                             if (!logFile.isFile()) {
                                 File oldFile = new File(jenkins.getRootDir(), HealthChecker.class.getName() + ".log");
                                 if (!logFile.getParentFile().isDirectory() && !logFile.getParentFile().mkdirs()) {
@@ -590,6 +590,12 @@ public class Metrics extends Plugin {
             } catch (Throwable t) {
                 logger.log(Level.SEVERE, HealthChecker.class.getName() + " thread failed with error", t);
             }
+        }
+
+        /* package */
+        static File getLogFile(Jenkins jenkins) {
+            File logsRoot = new File(jenkins.getRootDir(), "logs");
+            return new File(logsRoot, "health-checker.log");
         }
 
         /**

--- a/src/test/java/jenkins/metrics/api/MetricsTest.java
+++ b/src/test/java/jenkins/metrics/api/MetricsTest.java
@@ -1,0 +1,57 @@
+package jenkins.metrics.api;
+
+import hudson.util.VersionNumber;
+import jenkins.model.Jenkins;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MetricsTest {
+
+    private static final String SYSPROP_FOR_LOGS_PATH = "hudson.triggers.SafeTimerTask.logsTargetDir";
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+    @Rule
+    public RestartableJenkinsRule story = new RestartableJenkinsRule();
+
+    @BeforeClass
+    @AfterClass
+    public static void cleanProperty() throws IOException {
+        System.clearProperty(SYSPROP_FOR_LOGS_PATH);
+    }
+
+
+    @Issue("JENKINS-50291")
+    @Test
+    public void logsDirectory() {
+
+        // Lambda-ify when Java 8+
+        story.then(new RestartableJenkinsRule.Step() {
+            @Override
+            public void run(JenkinsRule j) throws Throwable {
+                Assume.assumeTrue(Jenkins.getVersion().isNewerThan(new VersionNumber("2.113"))); // JENKINS-50291 introduced in 2.114
+
+                assertTrue(Metrics.HealthChecker.getLogFile(j.jenkins).getAbsolutePath().startsWith(j.getInstance().getRootDir().getAbsolutePath()));
+                System.setProperty("hudson.triggers.SafeTimerTask.logsTargetDir", folder.newFolder().getAbsolutePath());
+            }
+        });
+
+        story.then(new RestartableJenkinsRule.Step() {
+            @Override
+            public void run(JenkinsRule j) throws Throwable {
+                assertFalse(Metrics.HealthChecker.getLogFile(j.jenkins).getAbsolutePath().startsWith(j.getInstance().getRootDir().getAbsolutePath()));
+            }
+        });
+    }
+}


### PR DESCRIPTION
Adjust the metrics-plugin to put logs under the now configurable logs root directory, introduced in Jenkins 2.114+ since [JENKINS-50291](https://issues.jenkins-ci.org/browse/JENKINS-50291).

To test this change:

```shell
mvn clean verify # => MetricsTest will be skipped because < 2.114
mvn clean verify -Dtest=MetricsTest -Djenkins.version=2.114 -Denforcer.skip=true # MetricsTest run successfully. Enforcer must be skipped to avoid failure because of bytecode version checks
```
@reviewbybees esp. @stephenc 