### PR TITLE
Update JCasC version to fix PCT errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.findbugs.failure.strict>true</maven.findbugs.failure.strict>
-    <jcasc.version>1.20</jcasc.version>
+    <jcasc.version>1.30</jcasc.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Executing PCT against newer jenkins versions fails with the following trace:

```
Error MessageThe log should have 'MetricsAccessKey.key = tDdG5Vsv-2-WDdHfI3QFPiU9-hcvKmWd2HL4CfVIFvUumQzz3qf6c0qt_HU4_lUh'Stacktracejava.lang.AssertionError: The log should have 'MetricsAccessKey.key = tDdG5Vsv-2-WDdHfI3QFPiU9-hcvKmWd2HL4CfVIFvUumQzz3qf6c0qt_HU4_lUh'at org.junit.Assert.fail(Assert.java:88)at org.junit.Assert.assertTrue(Assert.java:41)at io.jenkins.plugins.casc.misc.RoundTripAbstractTest.assertLogAsExpected(RoundTripAbstractTest.java:193)
```

After updating the JCasC version to latest one, the PCT succeeds.

@alecharp 
@oleg-nenashev @rsandell @varyvol @MRamonLeon 