### PR TITLE
Fix CI failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,5 +7,5 @@ buildPlugin(configurations: [
     [ platform: "linux", jdk: "8", jenkins: '2.222.1', javaLevel: "8" ],
 
     // Checking JDK 11 
-    // [ platform: "linux", jdk: "11", jenkins: null ]
+    [ platform: "linux", jdk: "11", jenkins: null ]
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,9 +3,9 @@ buildPlugin(configurations: [
     [ platform: "linux", jdk: "8", jenkins: null ],
     // [ platform: "windows", jdk: "8", jenkins: null ],
 
-    // // More recent LTS, only Linux
-    // [ platform: "windows", jdk: "8", jenkins: '2.222.1', javaLevel: "8" ],
+    // More recent LTS, only Linux
+    [ platform: "linux", jdk: "8", jenkins: '2.222.1', javaLevel: "8" ],
 
-    // // Checking JDK 11 
+    // Checking JDK 11 
     // [ platform: "linux", jdk: "11", jenkins: null ]
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,11 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(configurations: [
+    // Test Windows & Linux with default values
+    [ platform: "linux", jdk: "8", jenkins: null ],
+    // [ platform: "windows", jdk: "8", jenkins: null ],
+
+    // // More recent LTS, only Linux
+    // [ platform: "windows", jdk: "8", jenkins: '2.222.1', javaLevel: "8" ],
+
+    // // Checking JDK 11 
+    // [ platform: "linux", jdk: "11", jenkins: null ]
+])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 buildPlugin(configurations: [
     // Test Windows & Linux with default values
     [ platform: "linux", jdk: "8", jenkins: null ],
-    // [ platform: "windows", jdk: "8", jenkins: null ],
+    [ platform: "windows", jdk: "8", jenkins: null ],
 
     // More recent LTS, only Linux
     [ platform: "linux", jdk: "8", jenkins: '2.222.1', javaLevel: "8" ],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 buildPlugin(configurations: [
     // Test Windows & Linux with default values
     [ platform: "linux", jdk: "8", jenkins: null ],
-    [ platform: "windows", jdk: "8", jenkins: null ],
+    //[ platform: "windows", jdk: "8", jenkins: null ],
 
     // More recent LTS, only Linux
     [ platform: "linux", jdk: "8", jenkins: '2.222.1', javaLevel: "8" ],


### PR DESCRIPTION
(Edited description after the fact, for better up-front clarity)

For some unclear reason iI did not spend hours investigating, #58 PR was green. BUT the `master` branch started failing when it got merged.

The reason is that the `jenkins.version` in one combinatorial of `recommendedConfiguration` (2.164, which is older than `jenkins.version` of the metrics-plugin currently).is more 

This PR is fixing the Jenkinsfile by "exploding" the recommendedConfiguration with the various axis to be tested. This way we have control on the LTS to use (and it's bumped to the one declared in the pom.xml).