### PR TITLE
Check ci windows

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,5 +7,5 @@ buildPlugin(configurations: [
     [ platform: "linux", jdk: "8", jenkins: '2.222.1', javaLevel: "8" ],
 
     // Checking JDK 11 
-    // [ platform: "linux", jdk: "11", jenkins: null ]
+    [ platform: "linux", jdk: "11", jenkins: null ]
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,9 +3,9 @@ buildPlugin(configurations: [
     [ platform: "linux", jdk: "8", jenkins: null ],
     // [ platform: "windows", jdk: "8", jenkins: null ],
 
-    // // More recent LTS, only Linux
-    // [ platform: "windows", jdk: "8", jenkins: '2.222.1', javaLevel: "8" ],
+    // More recent LTS, only Linux
+    [ platform: "linux", jdk: "8", jenkins: '2.222.1', javaLevel: "8" ],
 
-    // // Checking JDK 11 
+    // Checking JDK 11 
     // [ platform: "linux", jdk: "11", jenkins: null ]
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,11 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(configurations: [
+    // Test Windows & Linux with default values
+    [ platform: "linux", jdk: "8", jenkins: null ],
+    // [ platform: "windows", jdk: "8", jenkins: null ],
+
+    // // More recent LTS, only Linux
+    // [ platform: "windows", jdk: "8", jenkins: '2.222.1', javaLevel: "8" ],
+
+    // // Checking JDK 11 
+    // [ platform: "linux", jdk: "11", jenkins: null ]
+])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 buildPlugin(configurations: [
     // Test Windows & Linux with default values
     [ platform: "linux", jdk: "8", jenkins: null ],
-    // [ platform: "windows", jdk: "8", jenkins: null ],
+    [ platform: "windows", jdk: "8", jenkins: null ],
 
     // More recent LTS, only Linux
     [ platform: "linux", jdk: "8", jenkins: '2.222.1', javaLevel: "8" ],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 buildPlugin(configurations: [
     // Test Windows & Linux with default values
     [ platform: "linux", jdk: "8", jenkins: null ],
-    //[ platform: "windows", jdk: "8", jenkins: null ],
+    [ platform: "windows", jdk: "8", jenkins: null ],
 
     // More recent LTS, only Linux
     [ platform: "linux", jdk: "8", jenkins: '2.222.1', javaLevel: "8" ],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 buildPlugin(configurations: [
     // Test Windows & Linux with default values
     [ platform: "linux", jdk: "8", jenkins: null ],
-    [ platform: "windows", jdk: "8", jenkins: null ],
+    //[ platform: "windows", jdk: "8", jenkins: null ],
 
     // More recent LTS, only Linux
     [ platform: "linux", jdk: "8", jenkins: '2.222.1', javaLevel: "8" ],


### PR DESCRIPTION
Follow-up on #72. It adds a single commit on top of it: https://github.com/jenkinsci/metrics-plugin/commit/ddc3dc95e2ba72422fe2304a416f40ca8b7193a0

As of now, this PR is expected to fail. The goal is to make `master` back to green, and this PR has a single commit and becomes a venue for understanding and fixing the windows failure.