### PR TITLE
Plugins should use slf4j-api version from Jenkins core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,11 +93,6 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>1.7.30</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -106,32 +101,72 @@
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
       <version>${metrics.version}</version>
+      <exclusions>
+        <exclusion>
+          <!-- The version from Jenkins core takes precedence at runtime. -->
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-servlet</artifactId>
       <version>${metrics.version}</version>
+      <exclusions>
+        <exclusion>
+          <!-- The version from Jenkins core takes precedence at runtime. -->
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-healthchecks</artifactId>
       <version>${metrics.version}</version>
+      <exclusions>
+        <exclusion>
+          <!-- The version from Jenkins core takes precedence at runtime. -->
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-jvm</artifactId>
       <version>${metrics.version}</version>
+      <exclusions>
+        <exclusion>
+          <!-- The version from Jenkins core takes precedence at runtime. -->
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-jmx</artifactId>
       <version>${metrics.version}</version>
+      <exclusions>
+        <exclusion>
+          <!-- The version from Jenkins core takes precedence at runtime. -->
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-json</artifactId>
       <version>${metrics.version}</version>
       <exclusions>
+        <exclusion>
+          <!-- The version from Jenkins core takes precedence at runtime. -->
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
         <exclusion>
           <!-- use the version supplied by jackson2-api -->
           <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
@joseblas was testing a version of this plugin that included #70, and I noticed that he had to add an explicit dependency on `slf4j-api` to solve an upper bounds conflict between this plugin and core, which should not be necessary. The problem appears to be the way dependency conflicts were fixed in https://github.com/jenkinsci/metrics-plugin/commit/38c3baa868fa4eedf26cc521ddbc1735f6b29505. Since [`slf4j-api` is in the core BOM](https://github.com/jenkinsci/jenkins/blob/7aa52381f8d716f19ff71d7cf37970767ed5bbac/bom/pom.xml#L111), any conflicts with it in a plugin must be solved by excluding the dependency from all paths other than core, which in this case means that all of the Dropwizard metrics library dependencies need an exclusion.

At runtime, the version from Jenkins core is what is going to be used anyway, so trying to resolve the `slf4j-api` conflicts here by requesting a different version in `dependencyManagement` does not actually fix the conflicts, it just hides them, and it means that any plugin that depends on `metrics` plugin is likely to run into the same upper bounds issues.
