### PR TITLE
Adding method to return subtask map 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <java.level>8</java.level>
     <jenkins.version>2.222.1</jenkins.version>
     <metrics.version>4.1.6</metrics.version>
-    <revision>4.0.2.9</revision>
+    <revision>4.0.2.11</revision>
     <changelist>-SNAPSHOT</changelist>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <java.level>8</java.level>
     <jenkins.version>2.222.1</jenkins.version>
     <metrics.version>4.1.6</metrics.version>
-    <revision>4.0.2.11</revision>
+    <revision>4.0.2.9</revision>
     <changelist>-SNAPSHOT</changelist>
   </properties>
 

--- a/src/main/java/jenkins/metrics/impl/TimeInQueueAction.java
+++ b/src/main/java/jenkins/metrics/impl/TimeInQueueAction.java
@@ -168,7 +168,7 @@ public class TimeInQueueAction implements Serializable, RunAction2 {
      * @return a map where each {@link SubTask} in this {@link Run} is mapped to each subtask's time in queue
      */
     @Exported(visibility = 2)
-    public Map<String, Long> getSubTaskMap() {
+    public Map<String, Long> getSubTaskQueuingDurations() {
 
         Map<String, Long> subtasks = new HashMap<String, Long>();
         if (run == null) {

--- a/src/main/java/jenkins/metrics/impl/TimeInQueueAction.java
+++ b/src/main/java/jenkins/metrics/impl/TimeInQueueAction.java
@@ -161,10 +161,11 @@ public class TimeInQueueAction implements Serializable, RunAction2 {
     }
 
      /**
-     * Returns the total time this {@link Run} spent queuing, including the time spent by subtasks. This is the sum
-     * of {@link #getQueuingDurationMillis()} plus all the {@link SubTaskTimeInQueueAction#getQueuingDurationMillis()}.
+     * Returns the a map of all the subtasks in this {@link Run} mapped to the time spent by each {@link SubTask} in queue.
+     * Subtasks are denoted in the map by chronological order and the subtask time in queue is denoted using
+     * {@link SubTaskTimeInQueueAction#getQueuingDurationMillis()}
      *
-     * @return the total time this {@link Run} spent queuing
+     * @return a map where each {@link SubTask} in this {@link Run} is mapped to each subtask's time in queue
      */
     @Exported(visibility = 2)
     public Map<String, Long> getSubTaskMap() {

--- a/src/main/java/jenkins/metrics/impl/TimeInQueueAction.java
+++ b/src/main/java/jenkins/metrics/impl/TimeInQueueAction.java
@@ -30,6 +30,8 @@ import hudson.model.Run;
 import hudson.model.queue.SubTask;
 import java.io.Serializable;
 import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import jenkins.model.RunAction2;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -156,6 +158,27 @@ public class TimeInQueueAction implements Serializable, RunAction2 {
             total += t.getQueuingDurationMillis();
         }
         return total;
+    }
+
+     /**
+     * Returns the total time this {@link Run} spent queuing, including the time spent by subtasks. This is the sum
+     * of {@link #getQueuingDurationMillis()} plus all the {@link SubTaskTimeInQueueAction#getQueuingDurationMillis()}.
+     *
+     * @return the total time this {@link Run} spent queuing
+     */
+    @Exported(visibility = 2)
+    public Map<String, Long> getSubTaskMap() {
+
+        Map<String, Long> subtasks = new HashMap<String, Long>();
+        if (run == null) {
+            return subtasks;
+        }
+        int subtask_count = 0;
+        for (SubTaskTimeInQueueAction t : run.getActions(SubTaskTimeInQueueAction.class)) {
+            subtasks.put("Subtask_" + subtask_count, t.getQueuingDurationMillis());
+            subtask_count = subtask_count + 1;
+        }
+        return subtasks;
     }
 
     /**


### PR DESCRIPTION
Goal: Find a way to access individual subtask metrics. Specifically, find a way to access individual subtask queue times. 

 

While metrics currently has functionality to allow for time in queue information to be extracted from the general job, it does not have the functionality capable of extracting time in queue information from individual subtasks. We found that we desire to implement a feature within metrics that would retrieve the subtask times of our pipeline jobs, as the current metrics don't allow for accurate queue time tracking when you have parallelized tasks. 

 

We accomplished this by returning a map that specifically maps each subtask in chronological order it entered the queue to the time it that each task spent waiting in queue. 


Our modifications included one function in TimeInQueueAction.java: **getSubTaskQueuingDurations()** 

  

![Screenshot from 2021-06-24 16-21-02](https://user-images.githubusercontent.com/85509505/123327406-607a1400-d508-11eb-9606-52fc649acdf2.png) 

 
   

getSubTaskQueuingDurations() makes a hash map that takes the subtask's relative order and maps it to the subtask queue time. Each subtask is given a number based on the order of when each one first entering the queue. 

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
