### PR TITLE
pin jackson2-api temporarily

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,8 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
+      <!-- TODO https://github.com/jenkinsci/bom/pull/1011 -->
+      <version>2.13.2.20220328-273.v11d70a_b_a_1a_52</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
We need to pin this to unblock https://github.com/jenkinsci/bom/pull/1011#issuecomment-1100675121

bump jackson2-api to avoid cyclic dependency

Once I have a incremental jar I can create PR for support-core plugin and than use that incremental jar in the bom!