### PR TITLE
Update plugin parent POM and BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
  ~ The MIT License
  ~
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.33</version>
+    <version>4.40</version>
     <relativePath />
   </parent>
 
@@ -38,10 +38,7 @@
   <packaging>hpi</packaging>
 
   <name>Metrics Plugin</name>
-  <description>
-    This plugin exposes the Metrics API to Jenkins plugins.
-  </description>
-  <url>https://github.com/jenkinsci/metrics-plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
   <licenses>
     <license>
       <name>The MIT license</name>
@@ -58,18 +55,18 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/metrics-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/metrics-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/metrics-plugin</url>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>
   </scm>
 
   <properties>
-    <java.level>8</java.level>
     <jenkins.version>2.319.1</jenkins.version>
     <metrics.version>4.1.6</metrics.version>
     <revision>4.1.6.2</revision>
     <changelist>-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
   <repositories>
@@ -90,7 +87,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.319.x</artifactId>
-        <version>1036.v9f5a1aba8fab</version>
+        <version>1280.vd669827e38cd</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    This plugin exposes the Metrics API to Jenkins plugins.
+</div>


### PR DESCRIPTION
Getting this released and adopted in `support-core` will help us cross the recent `jackson2-api` flag day and restore `support-core` to jenkinsci/bom as described in https://github.com/jenkinsci/bom/pull/1011, https://github.com/jenkinsci/support-core-plugin/pull/360, and https://github.com/jenkinsci/bom/pull/1016.

CC @alecharp @jetersen