### PR TITLE
Bump bom-2.346.x from 1438.v6a_2c29d73f82 to 1500.ve4d05cd32975

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.346.x</artifactId>
-        <version>1438.v6a_2c29d73f82</version>
+        <version>1500.ve4d05cd32975</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,12 @@
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.main</groupId>
+          <artifactId>jenkins-test-harness</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
unblocking https://github.com/jenkinsci/bom/pull/1275

Bumps [bom-2.346.x](https://github.com/jenkinsci/bom) from 1438.v6a_2c29d73f82 to 1500.ve4d05cd32975.
- [Release notes](https://github.com/jenkinsci/bom/releases)
- [Commits](https://github.com/jenkinsci/bom/commits)

---
updated-dependencies:
- dependency-name: io.jenkins.tools.bom:bom-2.346.x
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
