### PR TITLE
[JENKINS-69817] Fix addition of SubTaskTimeInQueueActions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.346.1</jenkins.version>
+    <jenkins.version>2.346.3</jenkins.version>
     <revision>4.2.10</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
@@ -194,6 +194,21 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/jenkins/metrics/impl/JenkinsMetricProviderImpl.java
+++ b/src/main/java/jenkins/metrics/impl/JenkinsMetricProviderImpl.java
@@ -1005,7 +1005,12 @@ public class JenkinsMetricProviderImpl extends MetricProvider {
             long executionDurationMillis = executor.getElapsedTime(); // i.e., now - startTime
             long startTime = System.currentTimeMillis() - executionDurationMillis;
             long queuingDurationMillis = startTime - item.getInQueueSince();
-            if (!wu.isMainWork()) {
+            Queue.Task owner = task.getOwnerTask();
+            while (owner != owner.getOwnerTask()) {
+                owner = owner.getOwnerTask();
+            }
+            // If this is a subtask
+            if (owner != task) {
                 run.ifPresent(r -> r.addAction(new SubTaskTimeInQueueAction(
                         queuingDurationMillis,
                         TimeUnit.NANOSECONDS.toMillis(t.blocked.get()),

--- a/src/test/java/jenkins/metrics/impl/JenkinsMetricProviderImplTest.java
+++ b/src/test/java/jenkins/metrics/impl/JenkinsMetricProviderImplTest.java
@@ -146,12 +146,10 @@ public class JenkinsMetricProviderImplTest {
     @Test
     @Issue("JENKINS-69817")
     public void given__a_job_with_subtasks__when__built__then__build_include_subtasks_metrics() throws Exception {
-        MyListener listener = ExtensionList.lookupSingleton(MyListener.class);
-        
         WorkflowJob p = j.createProject(WorkflowJob.class);
         p.setDefinition(new CpsFlowDefinition("node { sleep 1 }" +
             "\nnode { sleep 2 }", true));
-        WorkflowRun workflowRun = j.buildAndAssertAccess(p);
+        WorkflowRun workflowRun = j.buildAndAssertSuccess(p);
 
         List<TimeInQueueAction> timeInQueueActions = workflowRun.getActions(TimeInQueueAction.class);
         assertThat(timeInQueueActions, notNullValue());

--- a/src/test/java/jenkins/metrics/impl/JenkinsMetricProviderImplTest.java
+++ b/src/test/java/jenkins/metrics/impl/JenkinsMetricProviderImplTest.java
@@ -42,7 +42,6 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SleepBuilder;
 import org.jvnet.hudson.test.TestExtension;
-import org.opentest4j.AssertionFailedError;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -53,7 +52,6 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.emptyCollectionOf;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -147,19 +145,17 @@ public class JenkinsMetricProviderImplTest {
     @Issue("JENKINS-69817")
     public void given__a_job_with_subtasks__when__built__then__build_include_subtasks_metrics() throws Exception {
         WorkflowJob p = j.createProject(WorkflowJob.class);
-        p.setDefinition(new CpsFlowDefinition("node { sleep 1 }" +
-            "\nnode { sleep 2 }", true));
+        p.setDefinition(new CpsFlowDefinition("node { echo 'subtask1' }" +
+            "\nnode { echo 'subtask2' }", true));
         WorkflowRun workflowRun = j.buildAndAssertSuccess(p);
 
         List<TimeInQueueAction> timeInQueueActions = workflowRun.getActions(TimeInQueueAction.class);
         assertThat(timeInQueueActions, notNullValue());
         assertThat(timeInQueueActions, hasSize(1));
-        
+
         List<SubTaskTimeInQueueAction> subTaskActions = workflowRun.getActions(SubTaskTimeInQueueAction.class);
         assertThat(subTaskActions, notNullValue());
         assertThat(subTaskActions, hasSize(2));
-        assertThat(subTaskActions.get(0).getExecutingDurationMillis()/1000, equalTo(1L));
-        assertThat(subTaskActions.get(1).getExecutingDurationMillis()/1000, equalTo(2L));
     }
 
     @TestExtension

--- a/src/test/java/jenkins/metrics/impl/JenkinsMetricProviderImplTest.java
+++ b/src/test/java/jenkins/metrics/impl/JenkinsMetricProviderImplTest.java
@@ -31,13 +31,18 @@ import hudson.model.queue.QueueTaskFuture;
 import jenkins.metrics.api.Metrics;
 import jenkins.metrics.api.QueueItemMetricsEvent;
 import jenkins.metrics.api.QueueItemMetricsListener;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SleepBuilder;
 import org.jvnet.hudson.test.TestExtension;
+import org.opentest4j.AssertionFailedError;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -48,7 +53,9 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.emptyCollectionOf;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.notNullValue;
@@ -134,6 +141,34 @@ public class JenkinsMetricProviderImplTest {
         assertThat(events.get(2).getQueuingWaitingMillis().orElse(null), greaterThan(1500L));
         assertThat(events.get(2).getExecutingMillis().orElse(null), allOf(greaterThan(2500L), lessThan(3800L)));
         assertThat(events.get(2).getExecutorCount().orElse(null), is(1));
+    }
+
+    @Test
+    @Issue("JENKINS-69817")
+    public void given__a_job_with_subtasks__when__built__then__build_include_subtasks_metrics() throws Exception {
+        MyListener listener = ExtensionList.lookup(QueueItemMetricsListener.class).get(MyListener.class);
+        assertThat(listener, notNullValue());
+        
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "testSubTasks");
+        p.setDefinition(new CpsFlowDefinition("node { sleep 1 }" +
+            "\nnode { sleep 2 }", true));
+//        j.jenkins.setQuietPeriod(0);
+        WorkflowRun workflowRun = Optional.ofNullable(p.scheduleBuild2(0))
+            .orElseThrow(AssertionFailedError::new)
+            .waitForStart();
+        j.waitForCompletion(workflowRun);
+        j.waitUntilNoActivity();
+
+        List<TimeInQueueAction> timeInQueueActions = workflowRun.getActions(TimeInQueueAction.class);
+        assertThat(timeInQueueActions, notNullValue());
+        assertThat(timeInQueueActions, hasSize(1));
+        
+        List<SubTaskTimeInQueueAction> subTaskActions = workflowRun.getActions(SubTaskTimeInQueueAction.class);
+        assertThat(subTaskActions, notNullValue());
+        assertThat(subTaskActions, hasSize(2));
+        assertThat(subTaskActions.get(0).getExecutingDurationMillis()/1000, equalTo(1L));
+        assertThat(subTaskActions.get(1).getExecutingDurationMillis()/1000, equalTo(2L));
+        
     }
 
     @TestExtension


### PR DESCRIPTION
[JENKINS-69817](https://issues.jenkins.io/browse/JENKINS-69817)

* Supersedes https://github.com/jenkinsci/metrics-plugin/pull/190 with tests. cc @sundergopalsingh
* Fixes a regression caused by https://github.com/jenkinsci/metrics-plugin/pull/127 using the same logic that was there, that is find the main owner using a `while` loop and compare it to the current completed task: 

```
            Queue.Task owner = task.getOwnerTask();
            while (owner != owner.getOwnerTask()) {
                owner = owner.getOwnerTask();
            }
            if (owner != task) {
```



- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue