### PR TITLE
Fixes PrototypeJS usages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
 buildPlugin(configurations: [
-    [ platform: "linux", jdk: "8" ],
     [ platform: "linux", jdk: "11" ],
     [ platform: "linux", jdk: "17" ]
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.51</version>
+    <version>4.63</version>
     <relativePath />
   </parent>
 
@@ -62,7 +62,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.346.3</jenkins.version>
+    <jenkins.version>2.361.4</jenkins.version>
     <revision>4.2.13</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
@@ -85,8 +85,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.346.x</artifactId>
-        <version>1723.vcb_9fee52c9fc</version>
+        <artifactId>bom-2.361.x</artifactId>
+        <version>2089.va_6e157b_1ca_91</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/resources/jenkins/metrics/api/MetricsAccessKey/config.jelly
+++ b/src/main/resources/jenkins/metrics/api/MetricsAccessKey/config.jelly
@@ -31,12 +31,10 @@
       <span class="metrics-access-key-new-token-value"><!-- For javascript --></span>
       <div class="warning metrics-access-key-display-after-generation">${%TokenDisplayedOnce}</div>
     </div>
-    <span class="yui-button">
-      <button type="button" tabindex="0" data-target-url="${descriptor.descriptorFullUrl}/generateNewToken"
-              onclick="saveApiToken(this)">
-        ${%GenerateNewToken}
-      </button>
-    </span>
+    <button class="jenkins-button" type="button" tabindex="0" data-target-url="${descriptor.descriptorFullUrl}/generateNewToken"
+            onclick="saveApiToken(this)">
+      ${%GenerateNewToken}
+    </button>
     <l:copyButton message="${%NewTokenValueCopied}" clazz="metrics-access-key-copy invisible" tooltip="${%CopyToken}"/>
   </f:entry>
   <f:entry title="${%Description}" field="description">

--- a/src/main/resources/jenkins/metrics/api/MetricsAccessKey/resource.css
+++ b/src/main/resources/jenkins/metrics/api/MetricsAccessKey/resource.css
@@ -48,9 +48,6 @@
 .metrics-access-key-copy.invisible {
     display: none;
 }
-.metrics-access-key-copy.visible {
-    display: block;
-}
 
 .metrics-access-key-display-after-generation {
     margin-top: 5px;

--- a/src/main/resources/jenkins/metrics/api/MetricsAccessKey/resource.js
+++ b/src/main/resources/jenkins/metrics/api/MetricsAccessKey/resource.js
@@ -22,25 +22,26 @@
  * THE SOFTWARE.
  */
 function saveApiToken(button) {
-  if (button.hasClassName('request-pending')) {
+  if (button.classList.contains('request-pending')) {
     return;
   }
-  button.addClassName('request-pending');
-  const repeatedChunk = button.up('.repeated-chunk');
+  button.classList.add('request-pending');
+  const repeatedChunk = button.closest('.repeated-chunk');
 
   const targetUrl = button.getAttribute('data-target-url');
-  new Ajax.Request(targetUrl, {
+  fetch(targetUrl, {
     method: 'post',
-    onSuccess: function (resp) {
+  }).then((resp) => {
+    if (resp.ok) {
       const json = resp.responseJSON;
       if (json.status === 'error') {
-        button.removeClassName('request-pending');
+        button.classList.remove('request-pending');
       } else {
         const {tokenValue} = json.data;
         // The visible part, so it can be copied
         const tokenValueSpan = repeatedChunk.querySelector('span.metrics-access-key-new-token-value');
         tokenValueSpan.innerText = tokenValue;
-        tokenValueSpan.addClassName('visible');
+        tokenValueSpan.classList.add('visible');
 
         // The input sent to save the configuration
         repeatedChunk.querySelector('[name = "key"]').value = tokenValue;
@@ -48,15 +49,14 @@ function saveApiToken(button) {
         // Show the copy button
         const tokenCopyButton = repeatedChunk.querySelector('.copy-button');
         tokenCopyButton.setAttribute('text', tokenValue);
-        tokenCopyButton.removeClassName('invisible')
-        tokenCopyButton.addClassName('visible');
+        tokenCopyButton.classList.remove('invisible')
+        tokenCopyButton.classList.add('visible');
 
         // Show the warning message
-        repeatedChunk.querySelector('.metrics-access-key-display-after-generation')
-            .addClassName('visible');
+        repeatedChunk.querySelector('.metrics-access-key-display-after-generation').classList.add('visible');
 
         button.remove();
       }
-    },
+    }
   });
 }

--- a/src/main/resources/jenkins/metrics/api/MetricsAccessKey/resource.js
+++ b/src/main/resources/jenkins/metrics/api/MetricsAccessKey/resource.js
@@ -31,32 +31,34 @@ function saveApiToken(button) {
   const targetUrl = button.getAttribute('data-target-url');
   fetch(targetUrl, {
     method: 'post',
+    headers: crumb.wrap({}),
   }).then((resp) => {
     if (resp.ok) {
-      const json = resp.responseJSON;
-      if (json.status === 'error') {
-        button.classList.remove('request-pending');
-      } else {
-        const {tokenValue} = json.data;
-        // The visible part, so it can be copied
-        const tokenValueSpan = repeatedChunk.querySelector('span.metrics-access-key-new-token-value');
-        tokenValueSpan.innerText = tokenValue;
-        tokenValueSpan.classList.add('visible');
+      resp.json().then((json) => {
+        if (json.status === 'error') {
+          button.classList.remove('request-pending');
+        } else {
+          const {tokenValue} = json.data;
+          // The visible part, so it can be copied
+          const tokenValueSpan = repeatedChunk.querySelector('span.metrics-access-key-new-token-value');
+          tokenValueSpan.innerText = tokenValue;
+          tokenValueSpan.classList.add('visible');
 
-        // The input sent to save the configuration
-        repeatedChunk.querySelector('[name = "key"]').value = tokenValue;
+          // The input sent to save the configuration
+          repeatedChunk.querySelector('[name = "key"]').value = tokenValue;
 
-        // Show the copy button
-        const tokenCopyButton = repeatedChunk.querySelector('.copy-button');
-        tokenCopyButton.setAttribute('text', tokenValue);
-        tokenCopyButton.classList.remove('invisible')
-        tokenCopyButton.classList.add('visible');
+          // Show the copy button
+          const tokenCopyButton = repeatedChunk.querySelector('.copy-button');
+          tokenCopyButton.setAttribute('text', tokenValue);
+          tokenCopyButton.classList.remove('invisible')
+          tokenCopyButton.classList.add('visible');
 
-        // Show the warning message
-        repeatedChunk.querySelector('.metrics-access-key-display-after-generation').classList.add('visible');
+          // Show the warning message
+          repeatedChunk.querySelector('.metrics-access-key-display-after-generation').classList.add('visible');
 
-        button.remove();
-      }
+          button.remove();
+        }
+      });
     }
   });
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

ping @basil 

### Testing done

Following https://www.jenkins.io/blog/2023/05/12/removing-prototype-from-jenkins to fix the different PrototypeJS usage done in the plugin.

For testing, I run the plugin locally with `mvn hpi:run` and created 2 new `MetricsAccessKey`, generating the token multiple time (saving it each time) to see that the javascript console was not throwing errors and the values were saved in the correct entry in the configuration file.
I also restarted the instance to make sure the previously configured entries were correctly loaded.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
