### PR TITLE
`JenkinsMetricProviderImplTest.given__a_job__when__built__then__events_and_metrics_include_build` is flaky

### DIFF
--- a/src/test/java/jenkins/metrics/impl/JenkinsMetricProviderImplTest.java
+++ b/src/test/java/jenkins/metrics/impl/JenkinsMetricProviderImplTest.java
@@ -35,6 +35,7 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
@@ -90,6 +91,7 @@ public class JenkinsMetricProviderImplTest {
 
     }
 
+    @Ignore("TODO allOf(greaterThan(2500L), lessThan(3800L)) flaky: 3999 observed")
     @Test
     public void given__a_job__when__built__then__events_and_metrics_include_build() throws Exception {
         j.jenkins.setQuietPeriod(0);


### PR DESCRIPTION
Observed in PCT:

```
java.lang.AssertionError: 

Expected: (a value greater than <2500L> and a value less than <3800L>)
     but: a value less than <3800L> <3999L> was greater than <3800L>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at jenkins.metrics.impl.JenkinsMetricProviderImplTest.given__a_job__when__built__then__events_and_metrics_include_build(JenkinsMetricProviderImplTest.java:140)
```

Introduced in #40. Amended in 57681f7, 9546e06, and 9546e06 (at least).
