### PR TITLE
Adding new metric which shows the plugins with warnings. 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -224,6 +224,8 @@ A value other than `0` is typically indicative of a potential issue within the J
 `jenkins.plugins.withUpdate` (gauge):: The number of plugins in the Jenkins instance that have an newer version reported as available in the current Jenkins update center metadata held by Jenkins.
 This value is not indicative of an issue with Jenkins but high values can be used as a trigger to review the plugins with updates with a view to seeing whether those updates potentially contain fixes for issues that could be affecting your Jenkins instance.
 
+`jenkins.plugins.withWarnings` (gauge):: The number of plugins in the Jenkins instance that have a known warning (e.g. a security vulnerability).
+
 `jenkins.queue.blocked.value` (gauge):: The number of jobs that are in the Jenkins build queue and currently in the blocked state.
 
 `jenkins.queue.blocked.history` (histogram):: The historical statistics of `jenkins.queue.blocked.value`.

--- a/src/main/java/jenkins/metrics/impl/JenkinsMetricProviderImpl.java
+++ b/src/main/java/jenkins/metrics/impl/JenkinsMetricProviderImpl.java
@@ -88,6 +88,7 @@ import jenkins.metrics.api.QueueItemMetricsListener;
 import jenkins.metrics.util.AutoSamplingHistogram;
 import jenkins.model.Jenkins;
 import jenkins.model.ParameterizedJobMixIn;
+import jenkins.security.UpdateSiteWarningsMonitor;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 
@@ -485,6 +486,12 @@ public class JenkinsMetricProviderImpl extends MetricProvider {
                             }
                         }
                         return count;
+                    }
+                }),
+                metric(name("jenkins", "plugins", "withWarnings"), new CachedGauge<Integer>(5, TimeUnit.MINUTES) {
+                    @Override
+                    protected Integer loadValue() {
+                        return ExtensionList.lookupSingleton(UpdateSiteWarningsMonitor.class).getActivePluginWarningsByPlugin().size();
                     }
                 }),
                 metric(name("jenkins", "runs"), runCounters())


### PR DESCRIPTION
Fixes JENKINS-72647

Hi. I'm the maintainer of the https://github.com/jenkinsci/prometheus-plugin. We've got a PR to include metrics for plugins with vulnerabilities. https://github.com/jenkinsci/prometheus-plugin/issues/624. Got some time and I tought I might be providing a PR here. 


### Testing done
Unsure how to implement JUnit tests here so I manually tested it like that: 
Ran the plugin with hpi:run and checked if the prometheus plugin shows the new metric.


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

