### PR TITLE
[JENKINS-73950] Extract inline event handler from `MetricsAccessKey/config.jelly`

### DIFF
--- a/src/main/resources/jenkins/metrics/api/MetricsAccessKey/config.jelly
+++ b/src/main/resources/jenkins/metrics/api/MetricsAccessKey/config.jelly
@@ -31,8 +31,8 @@
       <span class="metrics-access-key-new-token-value"><!-- For javascript --></span>
       <div class="warning metrics-access-key-display-after-generation">${%TokenDisplayedOnce}</div>
     </div>
-    <button class="jenkins-button" type="button" tabindex="0" data-target-url="${descriptor.descriptorFullUrl}/generateNewToken"
-            onclick="saveApiToken(this)">
+    <button class="jenkins-button metrics-generate-api-token" type="button" tabindex="0"
+            data-target-url="${descriptor.descriptorFullUrl}/generateNewToken">
       ${%GenerateNewToken}
     </button>
     <l:copyButton message="${%NewTokenValueCopied}" clazz="metrics-access-key-copy invisible" tooltip="${%CopyToken}"/>

--- a/src/main/resources/jenkins/metrics/api/MetricsAccessKey/resource.js
+++ b/src/main/resources/jenkins/metrics/api/MetricsAccessKey/resource.js
@@ -63,8 +63,8 @@ function saveApiToken(button) {
   });
 }
 
-Behaviour.specify(".metrics-generate-api-token", "MetricsAccessKey_generateToken", 0, (element) => {
-  element.addEventListener("click", (event) => {
+Behaviour.specify('.metrics-generate-api-token', 'MetricsAccessKey_generateToken', 0, (element) => {
+  element.addEventListener('click', (event) => {
     saveApiToken(event.target);
   });
 });

--- a/src/main/resources/jenkins/metrics/api/MetricsAccessKey/resource.js
+++ b/src/main/resources/jenkins/metrics/api/MetricsAccessKey/resource.js
@@ -62,3 +62,9 @@ function saveApiToken(button) {
     }
   });
 }
+
+Behaviour.specify(".metrics-generate-api-token", "MetricsAccessKey_generateToken", 0, (element) => {
+  element.addEventListener("click", (event) => {
+    saveApiToken(event.target);
+  });
+});


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-73950

### Testing done
Generating new keys on the Global Configuration page triggers the violation.

https://www.loom.com/share/a33cdd98e0344c698baf78e79ad7c4fb

https://www.loom.com/share/8484f3e7bbf546ee872616fdf842cdad

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
