### PR TITLE
Add Queued detail

### DIFF
--- a/src/main/java/jenkins/metrics/impl/MetricsDetail.java
+++ b/src/main/java/jenkins/metrics/impl/MetricsDetail.java
@@ -1,0 +1,31 @@
+package jenkins.metrics.impl;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Util;
+import hudson.model.Actionable;
+import jenkins.metrics.api.Messages;
+import jenkins.model.details.Detail;
+
+public class MetricsDetail extends Detail {
+    public MetricsDetail(Actionable object) {
+        super(object);
+    }
+
+    @Nullable
+    @Override
+    public String getIconClassName() {
+        return "symbol-hourglass-outline plugin-ionicons-api";
+    }
+
+    @Nullable
+    @Override
+    public String getDisplayName() {
+        TimeInQueueAction timeInQueueAction = getObject().getAction(TimeInQueueAction.class);
+        return Messages.queued(Util.getTimeSpanString(timeInQueueAction.getQueuingDurationMillis()));
+    }
+
+    @Override
+    public int getOrder() {
+        return Integer.MAX_VALUE - 2;
+    }
+}

--- a/src/main/java/jenkins/metrics/impl/MetricsDetailFactory.java
+++ b/src/main/java/jenkins/metrics/impl/MetricsDetailFactory.java
@@ -1,0 +1,24 @@
+package jenkins.metrics.impl;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Run;
+import jenkins.model.details.Detail;
+import jenkins.model.details.DetailFactory;
+
+import java.util.List;
+
+@Extension
+public final class MetricsDetailFactory extends DetailFactory<Run> {
+
+    @Override
+    public Class<Run> type() {
+        return Run.class;
+    }
+
+    @NonNull
+    @Override
+    public List<? extends Detail> createFor(@NonNull Run target) {
+        return List.of(new MetricsDetail(target));
+    }
+}

--- a/src/main/resources/jenkins/metrics/api/Messages.properties
+++ b/src/main/resources/jenkins/metrics/api/Messages.properties
@@ -36,3 +36,4 @@ Metrics.HealthCheckPermission.Description=This permission grants access to the h
   this could be abused to deliver a denial of service attack if the credentials of a user with this permission \
   become compromised.
 Metrics.afterExtensionsAugmented=Registering metric provider and health check provider extensions
+queued=Queued {0}

--- a/src/main/resources/jenkins/metrics/impl/TimeInQueueAction/summary.jelly
+++ b/src/main/resources/jenkins/metrics/impl/TimeInQueueAction/summary.jelly
@@ -22,24 +22,28 @@
  ~ THE SOFTWARE.
  -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson">
-  <t:summary icon="symbol-stopwatch-outline plugin-ionicons-api" href="${it.urlName}" iconOnly="true">
-    <j:choose>
-      <j:when test="${it.buildingDurationMillis>0}">
-        <p>
-          ${%blurb}
-        </p>
-        <ul>
-          <li>${%waiting(it.queuingTimeString)}</li>
-          <li>${%building(it.buildingDurationString)}</li>
-          <li>${%total(it.totalDurationString)}</li>
-        </ul>
-      </j:when>
-      <j:otherwise>
-        <p>
-          ${%waiting_still_running(it.queuingTimeString)}
-        </p>
-      </j:otherwise>
-    </j:choose>
-  </t:summary>
+<j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson" xmlns:l="/lib/layout">
+  <l:userExperimentalFlag var="newBuildPage" flagClassName="jenkins.model.experimentalflags.NewBuildPageUserExperimentalFlag" />
+
+  <j:if test="${!newBuildPage}">
+    <t:summary icon="symbol-stopwatch-outline plugin-ionicons-api" href="${it.urlName}" iconOnly="true">
+      <j:choose>
+        <j:when test="${it.buildingDurationMillis>0}">
+          <p>
+            ${%blurb}
+          </p>
+          <ul>
+            <li>${%waiting(it.queuingTimeString)}</li>
+            <li>${%building(it.buildingDurationString)}</li>
+            <li>${%total(it.totalDurationString)}</li>
+          </ul>
+        </j:when>
+        <j:otherwise>
+          <p>
+            ${%waiting_still_running(it.queuingTimeString)}
+          </p>
+        </j:otherwise>
+      </j:choose>
+    </t:summary>
+  </j:if>
 </j:jelly>


### PR DESCRIPTION
[2.504.1](https://www.jenkins.io/changelog/2.504.1/) introduced a new `Detail` API, allowing core and plugin developers to attach details and groups to objects in Jenkins. This is currently only used by `Run` in core. 

This PR adds a 'Queued' detail so that users can see how long their run was queued for. This PR also hides the summary widget if the experimental flag in core is enabled.

<img width="617" height="44" alt="image" src="https://github.com/user-attachments/assets/d1d7a530-d108-4cfa-b678-fddf7d3bc685" />

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
